### PR TITLE
directly pass microamp-amp.o to the linker

### DIFF
--- a/tools/src/bin/cargo-microamp.rs
+++ b/tools/src/bin/cargo-microamp.rs
@@ -294,9 +294,7 @@ fn run() -> Result<i32, failure::Error> {
                 "-C",
                 &format!("link-arg=-Tcore{}.x", i),
                 "-C",
-                "link-arg=-L",
-                "-C",
-                &format!("link-arg={}", td.path().display()),
+                &format!("link-arg={}", obj.display()),
             ]);
             if verbose {
                 eprintln!("{:?}", c);


### PR DESCRIPTION
this way we don't need `INPUT(microamp-data.o)` (which the user may forget!) in
each linker script