### PR TITLE
Trait optin_builtin_traits has been renamed to auto-traits

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 #![doc(include = "../README.md")]
 #![feature(external_doc)]
 #![deny(missing_docs)]
-#![feature(optin_builtin_traits)]
+#![feature(auto_traits)]
 #![feature(negative_impls)]
 #![no_std]
 


### PR DESCRIPTION
Unable to compile microamp on stable with the error:

```
    Compiling microamp v0.1.0-alpha.5
error[E0557]: feature has been removed
 --> /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/microamp-0.1.0-alpha.5/src/lib.rs:6:12
  |
6 | #![feature(optin_builtin_traits)]
  |            ^^^^^^^^^^^^^^^^^^^^ feature has been removed
  |
  = note: renamed to `auto_traits`

error[E0658]: auto traits are experimental and possibly buggy
 --> /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/microamp-0.1.0-alpha.5/src/export.rs:1:1
  |
1 | pub auto trait DataNotCode {}
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: see issue #13231 <https://github.com/rust-lang/rust/issues/13231> for more information
  = help: add `#![feature(auto_traits)]` to the crate attributes to enable

error: aborting due to 2 previous errors
```

I think it makes sense to release another alpha with this change