### PR TITLE
Replace deprecated external_doc feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #![deny(rust_2018_compatibility)]
 #![deny(rust_2018_idioms)]
-#![doc(include = "../README.md")]
-#![feature(external_doc)]
+#![doc = include_str!("../README.md")]
 #![deny(missing_docs)]
 #![feature(auto_traits)]
 #![feature(negative_impls)]


### PR DESCRIPTION
Required with latest nightly

Currently random breaking https://github.com/rtic-rs/cortex-m-rtic/pull/520 PR